### PR TITLE
Better solution to #10

### DIFF
--- a/src/mode/command.cpp
+++ b/src/mode/command.cpp
@@ -623,6 +623,10 @@ void Command::SavePlaylist(std::string const & arguments)
          Main::Lists().Add(arguments);
          Main::Lists().Sort();
       }
+      else
+      {
+         client_.RemovePlaylist(arguments);
+      }
 
       client_.SavePlaylist(arguments);
    }


### PR DESCRIPTION
My last proposal left out the very important case where the playlist does not exist... oops. This one is tested with both scenarios. Basically, when using `:save` it will overwrite a playlist if it already exists.
