### PR TITLE
Add backslash escaping to string formatting.

### DIFF
--- a/src/song.cpp
+++ b/src/song.cpp
@@ -259,7 +259,13 @@ std::string Song::ParseString(std::string::const_iterator & it, bool & valid) co
 
    do
    {
-      if (*it == '{')
+      if (*it == '\\')
+      {
+         *++it;
+         result += *it;
+         continue;
+      }
+      else if (*it == '{')
       {
          *++it;
          result += ParseString(it, valid);


### PR DESCRIPTION
Here's the fix. Really simple.
