### PR TITLE
Fix blinking progress bar on song change.

### DIFF
--- a/src/mpdclient.cpp
+++ b/src/mpdclient.cpp
@@ -1713,13 +1713,6 @@ void Client::IncrementTime(long time)
       {
          UpdateStatus();
       }
-      else if ((currentSong_ != NULL) &&
-               (mpd_song_get_duration(currentSong_) > 0) &&
-               (elapsed_ >= mpd_song_get_duration(currentSong_)))
-      {
-         elapsed_ = 0;
-         UpdateStatus();
-      }
    }
    else
    {


### PR DESCRIPTION
The progress bar and status line sometimes blink in between songs.
For a demonstration, see this video: http://youtu.be/-Z4ZLjJc1Z4
