### PR TITLE
Fixes :addall error in #45.

### DIFF
--- a/src/mpdclient.cpp
+++ b/src/mpdclient.cpp
@@ -1336,7 +1336,9 @@ void Client::AddAllSongs()
       if (Connected() == true)
       {
          Debug("Client::Add all songs");
-         mpd_send_add(connection_, "/");
+         Main::Library().ForEachSong([this] (Mpc::Song * song) {
+            Add(song->URI().c_str());
+         });
       }
       else
       {


### PR DESCRIPTION
I get the same Malformed URI error when trying to use `/` in the `mpd_send_add` function. This is a workaround that seems to work.
