### PR TITLE
Add command to overwrite playlist.

### DIFF
--- a/src/mode/command.cpp
+++ b/src/mode/command.cpp
@@ -188,6 +188,7 @@ Command::Command(Main::Vimpc * vimpc, Ui::Screen & screen, Mpc::Client & client,
    AddCommand("edit",       true,  false, &Command::LoadPlaylist);
    AddCommand("w",          true,  false, &Command::SavePlaylist);
    AddCommand("write",      true,  false, &Command::SavePlaylist);
+   AddCommand("overwrite",  true,  false, &Command::OverwritePlaylist);
    AddCommand("toplaylist", true,  false, &Command::ToPlaylist);
 
    // Local socket commands
@@ -885,6 +886,19 @@ void Command::SavePlaylist(std::string const & arguments)
 {
    if (arguments != "")
    {
+      client_.SavePlaylist(arguments);
+   }
+   else
+   {
+      ErrorString(ErrorNumber::NoParameter);
+   }
+}
+
+void Command::OverwritePlaylist(std::string const & arguments)
+{
+   if (arguments != "")
+   {
+      client_.RemovePlaylist(arguments);
       client_.SavePlaylist(arguments);
    }
    else

--- a/src/mode/command.hpp
+++ b/src/mode/command.hpp
@@ -156,6 +156,7 @@ namespace Ui
    private:
       void LoadPlaylist(std::string const & arguments);
       void SavePlaylist(std::string const & arguments);
+      void OverwritePlaylist(std::string const & arguments);
       void ToPlaylist(std::string const & arguments);
 
       void Find(std::string const & arguments);


### PR DESCRIPTION
MPD, tragically, does not have good functionality for updating/editing an existing saved playlist. To update a playlist, what is actually done is that the playlist is deleted and then recreated with the edits.

I originally tried to rework the `:w` and `:write` to allow for updating an existing playlist. First I tried to always delete the playlist before creating it (see #40). However, if you wanted to make a new playlist, this removal would error, confusing the user. I wanted to only remove an existing playlist if it existed but could not, for the life of me could not figure out a way to do that.

Hopefully this works for now.
