### PR TITLE
Add some safety to seek* parameters

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -268,7 +268,8 @@
 
    volume [0-100]           | set the volume
 
-   seek <time>              | seek to <time>
+   seek <time>              | seek to <time>, where <time> is of the form
+                            |    <mm:ss>, <:ss>, or <ss>
    seek+ <time>             | seek forward <time>
    seek- <time>             | seek backward <time>
 

--- a/src/mode/command.cpp
+++ b/src/mode/command.cpp
@@ -543,39 +543,60 @@ template <int Delta>
 void Command::Seek(std::string const & arguments)
 {
    uint32_t time = 0;
+   int min = 0, sec = 0;
    size_t const pos = arguments.find_first_of(":");
 
    if (pos != std::string::npos)
    {
       std::string minutes = arguments.substr(0, pos);
       std::string seconds = arguments.substr(pos + 1);
-      time = (atoi(minutes.c_str()) * 60) + atoi(seconds.c_str());
+      min = atoi(minutes.c_str());
+      sec = atoi(seconds.c_str());
    }
    else
    {
-      time = atoi(arguments.c_str());
+      sec = atoi(arguments.c_str());
    }
-
-   Player::Seek(Delta * time);
+   
+   if (min < 0 || sec < 0)
+   {
+      ErrorString(ErrorNumber::InvalidParameter);
+   }
+   else
+   {
+      time = static_cast<uint32_t>( (min * 60) + sec );
+      Player::Seek(Delta * time);
+   }
 }
 
 void Command::SeekTo(std::string const & arguments)
 {
    uint32_t time = 0;
+   int min = 0, sec = 0;
    size_t const pos = arguments.find_first_of(":");
 
    if (pos != std::string::npos)
    {
       std::string minutes = arguments.substr(0, pos);
       std::string seconds = arguments.substr(pos + 1);
-      time = (atoi(minutes.c_str()) * 60) + atoi(seconds.c_str());
+      min = atoi(minutes.c_str()); // use int type so we can look for a 
+                                   // negative seek value
+      sec = atoi(seconds.c_str());
    }
    else
    {
-      time = atoi(arguments.c_str());
+      sec = atoi(arguments.c_str());
    }
 
-   Player::SeekTo(time);
+   if (min < 0 || sec < 0)
+   {
+      ErrorString(ErrorNumber::InvalidParameter);
+   }
+   else
+   {
+      time = static_cast<uint32_t>( (min * 60) + sec );
+      Player::SeekTo(time);
+   }
 }
 
 void Command::Quit(std::string const & arguments)


### PR DESCRIPTION
I entered `seek -10` in command mode and vimpc seemed to hang up and behave strangely.  I added some simple checks to see if the time entered in `seek`, `seek+`, or `seek-` is negative and throw an InvalidParameter error.

One thing that might be neat to implement is making a negative `seek` value seek from the end of the track.