### PR TITLE
Update shortcut and description for `toggle pause`

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -77,7 +77,7 @@
    [count] +                | increase volume
    [count] -                | decrease volume
 
-           p                | toggle pause on/off, or if stopped start playing
+           space            | toggle pause on/off or start playing
            s, backspace     | stop playback
 
            C                | toggle consume


### PR DESCRIPTION
The binding for toggling pause has been changed from `p` to `space` in commit 1be0c54713563817f8417b6a2ebf5db922408152. This hasn't been reflected in the help page so this commit does just that.