### PR TITLE
Make scroll to random line non-deterministic

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -790,6 +790,7 @@ void Screen::ScrollTo(Location location, uint32_t line)
    scroll[PlaylistNext] = ActiveWindow().Playlist(1);
    scroll[PlaylistPrev] = ActiveWindow().Playlist(-1);
    scroll[Specific]     = line - 1;
+   srand(time(0));
    scroll[Random]       = (ActiveWindow().BufferSize() > 0) ? (rand() % ActiveWindow().BufferSize()) : 0;
 
    ScrollTo(scroll[location]);


### PR DESCRIPTION
Previously, scrolling to a random line with the `%` key followed the exact same sequence between different vimpc instances. I used the `%` key to add a random album to my playlist, but was frustrated that I would get the same sequence of "random" albums suggested every time. Try this out by opening a new instance of `vimpc` and pressing `%` a few times, and note the selections after each press. When repeating this on a new session of `vimpc`, the exact same items are selected in the same order.

I have added a `srand` call to seed the pRNG with the current time before selecting a random line to scroll to. This way, the `%` will give a unique sequence of random jumps between vimpc instances.