### PR TITLE
Fix down wheel scroll with newer ncurses versions

### DIFF
--- a/src/mode/normal.cpp
+++ b/src/mode/normal.cpp
@@ -809,7 +809,8 @@ std::string Normal::MouseInputToString() const
 
    if (conversionTable.empty() == true)
    {
-#if (NCURSES_MOUSE_VERSION <= 1)
+#ifdef BUTTON5_PRESSED // New versions of Curses only support BUTTON5
+                       // for down scroll
       conversionTable[BUTTON5_PRESSED]        = "<ScrollWheelDown>";
 #endif
       conversionTable[BUTTON2_PRESSED]        = "<ScrollWheelDown>";


### PR DESCRIPTION
ncurses >= 6 seems to only trigger BUTTON5 on mouse wheel scroll down events.  As older versions did not declare BUTTON5, normal.cpp contained a preprocessor check for NCURSES_MOUSE_VERSION to account for this special case, but it no longer seems to work.  The following macro is a better catch-all and will trigger on BUTTON2 as well as BUTTON5 if linked ncurses version supports it:
```
#ifdef BUTTON5_PRESSED
      conversionTable[BUTTON5_PRESSED]        = "<ScrollWheelDown>";
#endif
      conversionTable[BUTTON2_PRESSED]        = "<ScrollWheelDown>";
```
This fixes scrolling on my system where NCURSES_MOUSE_VERSION = 2 and only BUTTON5 triggers.
