### PR TITLE
Fix integer overflow with negative scrolling

### DIFF
--- a/src/window/scrollwindow.cpp
+++ b/src/window/scrollwindow.cpp
@@ -226,7 +226,7 @@ void ScrollWindow::Resize(uint32_t rows, uint32_t columns)
 
 void ScrollWindow::Scroll(int32_t scrollCount)
 {
-   int64_t const newLine = (scrollLine_ + scrollCount);
+   int64_t const newLine = static_cast<int64_t>(scrollLine_) + scrollCount;
 
    if (BufferSize() > static_cast<uint32_t>(Rows()))
    {


### PR DESCRIPTION
In any list of length greater than the screen size, attempting large scroll commands causes an integer overflow and odd screen behavior, for example:
6000<Down_Arrow>
6000<Up_Arrow>
It's caused by scrollLine_ (unsigned integer) overflowing when a negative is added to it.