### PR TITLE
Trigger autoscroll every time the current song is updated

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -553,7 +553,7 @@ rendering a song. The default setting is ' '.
    -----------------------
    albumartist          | use the albumartist in preference to artist
    autolyrics           | automatically fetch lyrics as the songs change
-   autoscroll           | automatically scroll when skipping songs
+   autoscroll           | automatically scroll playlist when songs change
    autoscrolllyrics     | estimate to scroll lyrics as percents of song complete
    autoupdate           | automatically update mpd after tag changes
    browsenumbers        | display id numbers next to songs in the browse window

--- a/src/mpdclient.cpp
+++ b/src/mpdclient.cpp
@@ -2448,6 +2448,7 @@ void Client::UpdateStatus(bool ExpectUpdate)
                   (mpd_status_get_elapsed_time(currentStatus_) < mpdelapsed_) ||
                   (mpd_status_get_elapsed_time(currentStatus_) <= 3))))
             {
+               autoscroll_ = true;
                UpdateCurrentSong();
             }
 


### PR DESCRIPTION
If `autoscroll` setting is enabled let's scroll playlist to the current song every time when song change.
It is the default behaviour of many other mpd clients like Sonata or Cantata, it is so in ncmpc with `auto-center = yes`, and I think it's more convenient.