### PR TITLE
Comply with XDG Base Directory Specification

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -614,7 +614,7 @@ rendering a song. The default setting is ' '.
  CONFIGURATION FILE
  --------------------------------------------------
 
- The config file ~/.vimpcrc is a file containing vimpc commands
+ The config file $XDG_CONIFG_HOME/vimpc/vimpcrc is a file containing vimpc commands
  (without the preceeding : ). These commands can change mpd settings
  such as "consume on" as well as vimpc specific settings
  like "set nocolour".

--- a/doc/vimpc.1
+++ b/doc/vimpc.1
@@ -4,8 +4,8 @@ vimpc \- vi inspired Music Player Daemon (MPD) client.
 .SH SYNOPSIS
 .B vimpc [options]
 .SH DESCRIPTION
-.B vimpc 
-provides simple access to 
+.B vimpc
+provides simple access to
 .BR mpd (1)
 via a familiar vi style interface.
 
@@ -31,7 +31,7 @@ Specifies the host to connect to.
 .IP MPD_PORT
 Specifies the port to connect to.
 .SH FILES
-.I ~/.vimpcrc
+.I $XDG_CONFIG_HOME/vimpc/vimpcrc
 .RS
 Per user configuration file. Executes the contents as vimpc commands.
 .SH BUGS

--- a/doc/vimpcrc.example
+++ b/doc/vimpcrc.example
@@ -1,7 +1,7 @@
 " Configuration of vimpc is done using vimpc commands
 " these can include commands which require an mpd connection
 "
-" Copy this file to ~/.vimpcrc to use it
+" Copy this file to $XDG_CONFIG_HOME/vimpc/vimpcrc to use it
 "
 " NB: Comments are very basic and must be on their own line
 echo Parsing config file

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -15,7 +15,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   config.hpp - parses .vimpcrc file and executes commands
+   config.hpp - parses vimpcrc file and executes commands
    */
 
 #ifndef __MAIN__CONFIG
@@ -34,6 +34,12 @@ namespace Main
    }
 }
 
+
+bool fexists(const std::string& filename) {
+   std::ifstream ifile(filename.c_str());
+	return (bool)ifile;
+}
+
 bool Main::Config::ExecuteConfigCommands(Ui::Command & handler)
 {
    static bool configCommandsExecuted    = false;
@@ -47,11 +53,25 @@ bool Main::Config::ExecuteConfigCommands(Ui::Command & handler)
       static char const * const home_dir = getenv("HOME");
       static char const * const xdg_config_dir = getenv("XDG_CONFIG_HOME");
       std::string configFile;
+      std::string xdgPath;
 
-      if (xdg_config_dir != NULL)
-         configFile = std::string(xdg_config_dir).append("/vimpc/vimpcrc");
-      else
-         configFile = std::string(home_dir).append("/.vimpcrc");
+      if (xdg_config_dir)
+      {
+         xdgPath = std::string(xdg_config_dir).append("/vimpc/vimpcrc");
+      }
+      std::string configPath = std::string(home_dir).append("/.config/vimpc/vimpcrc");
+      std::string fallback = std::string(home_dir).append("/.vimpcrc");
+      if (xdg_config_dir != NULL && fexists(xdgPath)) {
+         configFile = xdgPath;
+      }
+      else if (fexists(configPath))
+      {
+         configFile = configPath;
+      }
+      else if (fexists(fallback))
+      {
+         configFile = fallback;
+      }
 
       std::ifstream inputStream(configFile);
       std::string input;


### PR DESCRIPTION
The [specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) states that if

> $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used".

This patch changes the unspecified default path from `~/.vimpcrc` to `~/.config/vimpc/vimpcrc` and updates the documentation to reflect the XDG location.