### PR TITLE
Reading song metadata from MPD's name tag

### DIFF
--- a/src/mpdclient.cpp
+++ b/src/mpdclient.cpp
@@ -2136,8 +2136,8 @@ void Client::GetAllMetaInformation()
       {
          EventData Data; Data.song = NULL; Data.uri = mpd_song_get_uri(nextSong); Data.pos1 = -1;
 
-         if (((settings_.Get(Setting::ListAllMeta) == false) &&
-              (Main::Library().Song(Data.uri) == NULL)) ||
+         if ((settings_.Get(Setting::ListAllMeta) == false) ||
+             (Main::Library().Song(Data.uri) == NULL) ||
              // Handle "virtual" songs embedded within files
              (mpd_song_get_end(nextSong) != 0))
          {
@@ -2510,11 +2510,13 @@ Song * Client::CreateSong(mpd_song const * const song) const
 
    //Debug("Alloc a song %d %d", count, sizeof(Song));
 
-   newSong->SetArtist     (mpd_song_get_tag(song, MPD_TAG_ARTIST, 0));
+   newSong->SetArtist     (mpd_song_get_tag(song, MPD_TAG_ARTIST,  0));
    newSong->SetAlbumArtist(mpd_song_get_tag(song, MPD_TAG_ALBUM_ARTIST, 0));
-   newSong->SetAlbum      (mpd_song_get_tag(song, MPD_TAG_ALBUM,  0));
-   newSong->SetTitle      (mpd_song_get_tag(song, MPD_TAG_TITLE,  0));
-   newSong->SetTrack      (mpd_song_get_tag(song, MPD_TAG_TRACK,  0));
+   newSong->SetAlbum      (mpd_song_get_tag(song, MPD_TAG_ALBUM,   0));
+   newSong->SetTitle      (mpd_song_get_tag(song, MPD_TAG_TITLE,   0));
+   newSong->SetTrack      (mpd_song_get_tag(song, MPD_TAG_TRACK,   0));
+   newSong->SetName       (mpd_song_get_tag(song, MPD_TAG_NAME,    0));
+   newSong->SetComment    (mpd_song_get_tag(song, MPD_TAG_COMMENT, 0));
    newSong->SetURI        (mpd_song_get_uri(song));
    newSong->SetGenre      (mpd_song_get_tag(song, MPD_TAG_GENRE, 0));
    newSong->SetDate       (mpd_song_get_tag(song, MPD_TAG_DATE, 0));

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -87,7 +87,7 @@
    /* Lists to show in the lists window */ \
    X(Playlists,        "playlists", "mpd", "all|mpd|files") \
    /* Song format string */ \
-   X(SongFormat,       "songformat", "{{%a - }%t}|{%f}$E$R $H[$H%l$H]$H", ".*") \
+   X(SongFormat,       "songformat", "{{%a - }%t}|{%N}|{%f}$E$R $H[$H%l$H]$H", ".*") \
    /* Song format fill character */ \
    X(SongFillChar,       "songfillchar", " ", ".") \
    /* Sort based on song format */ \

--- a/src/song.cpp
+++ b/src/song.cpp
@@ -26,14 +26,16 @@
 #include "buffer/directory.hpp"
 #include "buffer/library.hpp"
 
-const std::string UnknownArtist = "Unknown Artist";
-const std::string UnknownAlbum  = "Unknown Album";
-const std::string UnknownTitle  = "Unknown";
-const std::string UnknownURI    = "Unknown";
-const std::string UnknownGenre  = "Unknown";
-const std::string UnknownTrack  = "";
-const std::string UnknownDate   = "Unknown";
-const std::string UnknownDisc   = "";
+const std::string UnknownArtist  = "Unknown Artist";
+const std::string UnknownAlbum   = "Unknown Album";
+const std::string UnknownTitle   = "Unknown";
+const std::string UnknownName    = "Unknown";
+const std::string UnknownComment = "Unknown";
+const std::string UnknownURI     = "Unknown";
+const std::string UnknownGenre   = "Unknown";
+const std::string UnknownTrack   = "";
+const std::string UnknownDate    = "Unknown";
+const std::string UnknownDisc    = "";
 
 std::vector<std::string> Mpc::Song::Artists;
 std::map<std::string, uint32_t> Mpc::Song::ArtistMap;
@@ -70,6 +72,8 @@ Song::Song() :
    virtualEnd_  (0),
    uri_         (""),
    title_       (""),
+   name_        (""),
+   comment_     (""),
    lastFormat_  (""),
    formatted_   (""),
    entry_       (NULL)
@@ -87,6 +91,8 @@ Song::Song(Song const & song) :
    duration_    (song.duration_),
    uri_         (song.URI()),
    title_       (song.Title()),
+   name_        (song.Name()),
+   comment_     (song.Comment()),
    lastFormat_  (song.lastFormat_),
    formatted_   (song.formatted_)
 {
@@ -251,6 +257,44 @@ std::string const & Song::Title() const
    return title_;
 }
 
+void Song::SetName(const char * name)
+{
+   lastFormat_ = "";
+
+   if (name != NULL)
+   {
+      name_ = name;
+   }
+   else
+   {
+      name_ = UnknownName;
+   }
+}
+
+std::string const & Song::Name() const
+{
+   return name_;
+}
+
+void Song::SetComment(const char * comment)
+{
+   lastFormat_ = "";
+
+   if (comment != NULL)
+   {
+      comment_ = comment;
+   }
+   else
+   {
+      comment_ = UnknownComment;
+   }
+}
+
+std::string const & Song::Comment() const
+{
+   return comment_;
+}
+
 void Song::SetTrack(const char * track)
 {
    Set(track, track_, Tracks, TrackMap);
@@ -395,9 +439,11 @@ std::string Song::FormatString(std::string fmt) const
    SongInfo['l'] = &Mpc::Song::DurationString;
    SongInfo['t'] = &Mpc::Song::Title;
    SongInfo['n'] = &Mpc::Song::Track;
+   SongInfo['N'] = &Mpc::Song::Name;
    SongInfo['f'] = &Mpc::Song::URI;
    SongInfo['d'] = &Mpc::Song::Date;
    SongInfo['c'] = &Mpc::Song::Disc;
+   SongInfo['C'] = &Mpc::Song::Comment;
 
    SongInfo['r'] = &Mpc::Song::Artist;
    SongInfo['R'] = &Mpc::Song::Artist;
@@ -472,8 +518,9 @@ std::string Song::ParseString(std::string::const_iterator & it, bool valid) cons
                   (*it == 'r') || (*it == 'R') ||
                   (*it == 'm') || (*it == 'M') ||
                   (*it == 'l') || (*it == 't') ||
-                  (*it == 'n') || (*it == 'f') ||
-                  (*it == 'd') || (*it == 'c'))
+                  (*it == 'n') || (*it == 'N') ||
+                  (*it == 'f') || (*it == 'd') ||
+                  (*it == 'c') || (*it == 'C'))
          {
             SongFunction Function = SongInfo[*it];
             std::string val = (*this.*Function)();

--- a/src/song.hpp
+++ b/src/song.hpp
@@ -108,6 +108,12 @@ namespace Mpc
       void SetTitle(const char * title);
       std::string const & Title() const;
 
+      void SetName(const char * name);
+      std::string const & Name() const;
+
+      void SetComment(const char * comment);
+      std::string const & Comment() const;
+
       void SetTrack(const char * track);
       std::string const & Track() const;
 
@@ -176,6 +182,8 @@ namespace Mpc
       int32_t     virtualEnd_;
       std::string uri_;
       std::string title_;
+      std::string name_;
+      std::string comment_;
 
       mutable std::string lastFormat_;
       mutable std::string formatted_;

--- a/src/window/infowindow.cpp
+++ b/src/window/infowindow.cpp
@@ -84,32 +84,42 @@ void InfoWindow::Print(uint32_t line) const
          wprintw(window, "%s", song->Title().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 8, 0, " Duration    : ");
+         mvwaddstr(window, 8, 0, " Name        : ");
+         wattroff(window, A_BOLD);
+         wprintw(window, "%s", song->Name().c_str());
+
+         wattron(window, A_BOLD);
+         mvwaddstr(window, 9, 0, " Duration    : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%d:%.2d", Mpc::SecondsToMinutes(song->Duration()), Mpc::RemainingSeconds(song->Duration()));
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 9, 0, " Genre       : ");
+         mvwaddstr(window, 10, 0, " Genre       : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", song->Genre().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 10, 0, " Date        : ");
+         mvwaddstr(window, 11, 0, " Comment     : ");
+         wattroff(window, A_BOLD);
+         wprintw(window, "%s", song->Comment().c_str());
+
+         wattron(window, A_BOLD);
+         mvwaddstr(window, 12, 0, " Date        : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", song->Date().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 11, 0, " Disc        : ");
+         mvwaddstr(window, 13, 0, " Disc        : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", song->Disc().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 13, 0, " Playlist    : ");
+         mvwaddstr(window, 15, 0, " Playlist    : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", (song->Reference() > 0) ? "Yes" : "No");
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 14, 0, " Position    : ");
+         mvwaddstr(window, 15, 0, " Position    : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%d", Main::Playlist().Index(song) + 1);
 


### PR DESCRIPTION
Like #63, I was trying to play an HTTP stream from a m3u file (with song names inside `#EXTINF` directives). The playlist screen only show the URL but not the song names. After looking at mpc source, it seems like the extended m3u metadata is stored inside the name tag. 

This PR allows vimpc to get name and comment tag from MPD and display them.

One thing I'm uncertain is on src/mpdclient.cpp:2139, I had to change `&&` to `||` for the tags to update. It's probably not good as it changes the old behaviour, so I'd appreciate for advice on how to change that.

This is my first PR, please tell me if I can improve anything. Thanks very much.