### PR TITLE
Extended M3U Playlists: Reading song metadata from MPD's name tag.

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -487,6 +487,8 @@
     %n    - Track number
     %N    - Track number zero padded to two digits
     %c    - Disc number
+    %P    - Song name, This is not the song title
+    %C    - Comment
     %l    - Duration
     %f    - Filename/URI
 
@@ -501,7 +503,7 @@ The setting songfillchar is used to fill up space due to alignment when
 rendering a song. The default setting is ' '.
 
  Examples:
-    The default song format is: "{%a - %t}\|{%f}$E$R $H[$H%l$H]$H"
+    The default song format is: "{{%a - }%t}\|{%P}\|{%f}$E$R $H[$H%l$H]$H"
     This displays artist - title if they both exist otherwise
     displays the filename and displays the duration aligned
     to the right. The $H ensures that [ and ] will not change

--- a/src/clientstate.cpp
+++ b/src/clientstate.cpp
@@ -372,17 +372,23 @@ void ClientState::DisplaySongInformation()
       {
          char const * const cartist  = mpd_song_get_tag(currentSong_, MPD_TAG_ARTIST, 0);
          char const * const ctitle   = mpd_song_get_tag(currentSong_, MPD_TAG_TITLE, 0);
+         char const * const cname    = mpd_song_get_tag(currentSong_, MPD_TAG_NAME, 0);
          char const * const curi     = mpd_song_get_uri(currentSong_);
          uint32_t     const duration = mpd_song_get_duration(currentSong_);
          uint32_t     const elapsed  = elapsed_;
          uint32_t     const remain   = (duration > elapsed) ? duration - elapsed : 0;
          std::string  const artist   = (cartist != NULL) ? cartist : "Unknown";
          std::string  const title    = (ctitle != NULL) ? ctitle : "";
+         std::string  const name     = (cname != NULL) ? cname : "";
          std::string  const uri      = (curi != NULL) ? curi : "";
 
          if (title != "")
          {
             snprintf(titleStr, 512, "%s - %s", artist.c_str(), title.c_str());
+         }
+         else if (name != "")
+         {
+            snprintf(titleStr, 512, "%s", name.c_str());
          }
          else
          {

--- a/src/mpdclient.cpp
+++ b/src/mpdclient.cpp
@@ -2133,7 +2133,7 @@ void Client::GetAllMetaInformation()
       {
          EventData Data; Data.song = NULL; Data.uri = mpd_song_get_uri(nextSong); Data.pos1 = -1;
 
-         if (((settings_.Get(Setting::ListAllMeta) == false) &&
+         if (((settings_.Get(Setting::ListAllMeta) == false) ||
               (Main::Library().Song(Data.uri) == NULL)) ||
              // Handle "virtual" songs embedded within files
              (mpd_song_get_end(nextSong) != 0))
@@ -2512,6 +2512,8 @@ Song * Client::CreateSong(mpd_song const * const song) const
    newSong->SetAlbum      (mpd_song_get_tag(song, MPD_TAG_ALBUM,  0));
    newSong->SetTitle      (mpd_song_get_tag(song, MPD_TAG_TITLE,  0));
    newSong->SetTrack      (mpd_song_get_tag(song, MPD_TAG_TRACK,  0));
+   newSong->SetName       (mpd_song_get_tag(song, MPD_TAG_NAME,    0));
+   newSong->SetComment    (mpd_song_get_tag(song, MPD_TAG_COMMENT, 0));
    newSong->SetURI        (mpd_song_get_uri(song));
    newSong->SetGenre      (mpd_song_get_tag(song, MPD_TAG_GENRE, 0));
    newSong->SetDate       (mpd_song_get_tag(song, MPD_TAG_DATE, 0));
@@ -2552,7 +2554,7 @@ void Client::QueueMetaChanges()
          {
             Song * newSong = NULL;
 
-            if (((settings_.Get(Setting::ListAllMeta) == false) &&
+            if (((settings_.Get(Setting::ListAllMeta) == false) ||
                  (Main::Library().Song(Data.uri) == NULL)) ||
                 // Handle "virtual" songs embedded within files
                 (mpd_song_get_end(nextSong) != 0))

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -88,7 +88,7 @@
    /* Lists to show in the lists window */ \
    X(Playlists,        "playlists", "mpd", "all|mpd|files") \
    /* Song format string */ \
-   X(SongFormat,       "songformat", "{{%a - }%t}|{%f}$E$R $H[$H%l$H]$H", ".*") \
+   X(SongFormat,       "songformat", "{{%a - }%t}|{%P}|{%f}$E$R $H[$H%l$H]$H", ".*") \
    /* Song format fill character */ \
    X(SongFillChar,       "songfillchar", " ", ".") \
    /* Sort based on song format */ \

--- a/src/song.hpp
+++ b/src/song.hpp
@@ -108,6 +108,12 @@ namespace Mpc
       void SetTitle(const char * title);
       std::string const & Title() const;
 
+      void SetName(const char * name);
+      std::string const & Name() const;
+
+      void SetComment(const char * comment);
+      std::string const & Comment() const;
+
       void SetTrack(const char * track);
       std::string const & Track() const;
       std::string const & ZeroPaddedTrack() const;
@@ -178,6 +184,8 @@ namespace Mpc
       int32_t     virtualEnd_;
       std::string uri_;
       std::string title_;
+      std::string name_;
+      std::string comment_;
 
       mutable std::string lastFormat_;
       mutable std::string formatted_;

--- a/src/window/infowindow.cpp
+++ b/src/window/infowindow.cpp
@@ -84,32 +84,42 @@ void InfoWindow::Print(uint32_t line) const
          wprintw(window, "%s", song->Title().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 8, 0, " Duration    : ");
+         mvwaddstr(window, 8, 0, " Name        : ");
+         wattroff(window, A_BOLD);
+         wprintw(window, "%s", song->Name().c_str());
+
+         wattron(window, A_BOLD);
+         mvwaddstr(window, 9, 0, " Duration    : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%d:%.2d", Mpc::SecondsToMinutes(song->Duration()), Mpc::RemainingSeconds(song->Duration()));
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 9, 0, " Genre       : ");
+         mvwaddstr(window, 10, 0, " Genre       : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", song->Genre().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 10, 0, " Date        : ");
+         mvwaddstr(window, 11, 0, " Comment     : ");
+         wattroff(window, A_BOLD);
+         wprintw(window, "%s", song->Comment().c_str());
+
+         wattron(window, A_BOLD);
+         mvwaddstr(window, 12, 0, " Date        : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", song->Date().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 11, 0, " Disc        : ");
+         mvwaddstr(window, 13, 0, " Disc        : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", song->Disc().c_str());
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 13, 0, " Playlist    : ");
+         mvwaddstr(window, 14, 0, " Playlist    : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%s", (song->Reference() > 0) ? "Yes" : "No");
 
          wattron(window, A_BOLD);
-         mvwaddstr(window, 14, 0, " Position    : ");
+         mvwaddstr(window, 15, 0, " Position    : ");
          wattroff(window, A_BOLD);
          wprintw(window, "%d", Main::Playlist().Index(song) + 1);
 


### PR DESCRIPTION
**This Pull Request is just an updated copy of @Rio6's [PR #93](https://github.com/boysetsfrog/vimpc/pull/93)** and related to [issue #63](https://github.com/boysetsfrog/vimpc/issues/63).

- I just updated the place of @Rio6's PR modifications in the current master and the name of `%N` to `%P`.
- I am not sure of the impact of the change in some conditions from `&&` to `||` like commented by @Rio6 in his PR, it needs some review.
- It does not cover all the places where vimpc could use the metadata from the playlist comments, but the most visible ones.
- It works fine for me.


----

## Introduction

My mpd.conf contains the following definitions:

```conf
playlist_directory              "~/.config/mpd/playlists"

playlist_plugin {
    name "extm3u"
    enabled "true"                                              
}
```

In the playlist_directory I have some playlist files in [Extended M3U format](https://en.wikipedia.org/wiki/M3U#Extended_M3U).
  - Example of UTF-8 Extended M3U file content with one web radio stream and one mp3 file  (`~/.config/mpd/test.m3u`):

```extm3u
#EXTM3U
#EXTENC:UTF-8
#PLAYLIST:Test
#EXTINF:-1,Sud Radio - Web radio
#EXTART:Sud Radio
#EXTGRP:STREAMS
https://ice.creacast.com/sudradio
#EXTINF:-1,Lady Pank - Zamki na piasku
#EXTART:Lady Pank
#EXTGRP:MP3
/home/user/Music/Lady Pank/Lady Pank - Lady Pank/07 - Zamki na piasku.mp3
```
  - Only the `#EXTM3U`, `#EXTINF` and the URL or filepath are of interest for this PR.

**But, vimpc does not fetch the information from `EXTINF` even if MPD does provide it.**

  - In the "playlist" tab:
    - The lines linked to a stream is just named with the URL. It does not change when playing.
    - The line linked to an mp3 file is described correctly with metadatas.
    - The 'e' key for information does not work for lines with streams.
  - In the Status line:
    - When the stream is launching, it displays the URL, and then the metadata fetched from the stream.
    - If it misses some information from the stream like the artist name, it displays "Unknown - ".
  - In the "list" tab:
    - The 'e' key for information open a tab for the list, but only the files are described, stream lines are missing.


## Solution

**This PR introduces 2 new tags (name and comment) and modify the songformat.**

Differences after this PR:

  - In the "playlist" tab:
    - The lines linked to a stream are **named as the `EXTINF`**. It's updated from the stream when playing.
    - The line linked to an mp3 file is described **correctly with metadatas, not from `EXTINF`**.
    - The 'e' key for information still does not work for lines with streams.
  - In the Status line:
    - When the stream is launching **it displays the `EXTINF` name, and then the metadata fetched from the stream.**
    - If it misses some information from the stream like the artist name, **it still displays "Unknown - " and does not use informations from `EXTINF`**.
  - In the "list" tab:
    - The 'e' key for information open a tab for the list, but still only the files are described, stream lines are missing.
