### PR TITLE
ui: fix rightmost character on last row being replaced by blank

### DIFF
--- a/src/window/scrollwindow.cpp
+++ b/src/window/scrollwindow.cpp
@@ -202,7 +202,7 @@ void ScrollWindow::Print(uint32_t line) const
    // Finish the line
    const int32_t curx = getcurx(window);
    const int32_t remaining_space = Columns()-curx;
-   curx && remaining_space && wprintw(window, "%s", std::string(remaining_space, ' ').c_str());
+   curx && A_CHARTEXT & winch(window) == ' ' && wprintw(window, "%s", std::string(remaining_space, ' ').c_str());
 
    return;
 }


### PR DESCRIPTION
Fixes a small bug in the scroll window that causes the rightmost character on the last row to be overwritten by a blank. For the default songformat, closing square bracket on last row gets replaced by blank. I have attached the screenshot for reference.

![vimpc](https://github.com/user-attachments/assets/974282c5-b528-4c20-8214-6ae1463426f4)
