### PR TITLE
Fix segfault when moving up a directory

### DIFF
--- a/src/window/directorywindow.cpp
+++ b/src/window/directorywindow.cpp
@@ -343,7 +343,6 @@ void DirectoryWindow::Confirm()
 
          AddLine(CurrentLine(), 1, false);
          client_.Play(0);
-         SelectWindow::Confirm();
       }
    }
 

--- a/src/window/directorywindow.cpp
+++ b/src/window/directorywindow.cpp
@@ -322,8 +322,19 @@ void DirectoryWindow::Confirm()
    {
       if (directory_.Get(CurrentLine())->type_ == Mpc::PathType)
       {
+         bool is_parent_dir = directory_.Get(CurrentLine())->name_ == "..";
          directory_.ChangeDirectory(*directory_.Get(CurrentLine()));
-         ScrollTo(0);
+
+         if (is_parent_dir)
+         {
+            ScrollTo(selection_.top());
+            selection_.pop();
+         }
+         else
+         {
+            selection_.push(CurrentLine());
+            ScrollTo(0);
+         }
       }
       else
       {


### PR DESCRIPTION
* Fixes a segfault when leaving a directory with 'h' or the left arrow key after entering with Enter.
* Remove redundant call to SelectWindow::Confirm().

Closes #97