### PR TITLE
Add support for 256-color palette

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -387,10 +387,14 @@
 
  HIGHLIGHTING:
    hi <prop> <bg> <fg>      | highlight a property with colors
-                            | standard 16 term colors are available
-                            | and specified as default, red, green, etc.
+                            | supports 256-color palette
+                            | use value from 0-255
+                            | standard 16 term colors are
+                            | specified as default, red, green, etc.
                             | for bold colors use the prefix bold_
                             | Ex: hi status default bold_white
+                            | Ex: hi status 40 black
+                            | Ex: hi status 226 21
 
    Properties:
    --------------------------

--- a/src/colours.cpp
+++ b/src/colours.cpp
@@ -20,27 +20,9 @@
 
 #include "colours.hpp"
 
-#define BACKGROUND(X) (16 + (16 * X))
 #define BOLD(X) (8 + X)
 
 using namespace Main;
-
-Colours::Colours()
-{
-   Song           = COLOR_WHITE;
-   SongId         = COLOR_RED;
-   Directory      = COLOR_RED;
-   CurrentSong    = COLOR_BLUE;
-   TabWindow      = BACKGROUND(COLOR_BLUE);
-   ProgressWindow = COLOR_RED;
-   SongMatch      = COLOR_YELLOW;
-   PartialAdd     = COLOR_CYAN;
-   FullAdd        = COLOR_GREEN;
-   PagerStatus    = COLOR_GREEN;
-
-   Error          = BACKGROUND(COLOR_RED);
-   StatusLine     = BACKGROUND(COLOR_BLUE);
-}
 
 bool Colours::InitialiseColours()
 {
@@ -54,15 +36,19 @@ bool Colours::InitialiseColours()
       if ((start_color() != ERR) && (use_default_colors() != ERR))
       {
          success = true;
-         int f, b;
-         for( b = -1; b < 16; ++b ) {
-            for( f = 0; f < 16; ++f ) {
-               if (b == -1)
-                  init_pair(f, f, b);
-               else
-                  init_pair((b * 16) + 16 + f, f, b );
-            }
-         }
+
+         init_pair(Song, COLOR_WHITE, COLOR_DEFAULT);
+         init_pair(SongId, COLOR_RED, COLOR_DEFAULT);
+         init_pair(Directory, COLOR_RED, COLOR_DEFAULT);
+         init_pair(CurrentSong, COLOR_BLUE, COLOR_DEFAULT);
+         init_pair(TabWindow, COLOR_BLACK, COLOR_BLUE);
+         init_pair(ProgressWindow, COLOR_RED, COLOR_DEFAULT);
+         init_pair(SongMatch, COLOR_YELLOW, COLOR_DEFAULT);
+         init_pair(PartialAdd, COLOR_CYAN, COLOR_DEFAULT);
+         init_pair(FullAdd, COLOR_GREEN, COLOR_DEFAULT);
+         init_pair(PagerStatus, COLOR_GREEN, COLOR_DEFAULT);
+         init_pair(Error, COLOR_BLACK, COLOR_RED);
+         init_pair(StatusLine, COLOR_BLACK, COLOR_BLUE);
       }
    }
 

--- a/src/colours.hpp
+++ b/src/colours.hpp
@@ -21,7 +21,6 @@
 #ifndef __MAIN__COLOURS
 #define __MAIN__COLOURS
 
-#define BACKGROUND(X) (16 + (16 * X))
 #define BOLD(X) (8 + X)
 #define COLOR_DEFAULT -1
 
@@ -32,21 +31,23 @@ namespace Main
    class Colours
    {
       public:
-      int Song;
-      int SongId;
-      int Directory;
-      int CurrentSong;
-      int TabWindow;
-      int ProgressWindow;
-      int SongMatch;
-      int PartialAdd;
-      int FullAdd;
-      int PagerStatus;
 
-      int Error;
-      int StatusLine;
+      enum Property : uint8_t {
+         Song = 1,
+         SongId,
+         Directory,
+         CurrentSong,
+         TabWindow,
+         ProgressWindow,
+         SongMatch,
+         PartialAdd,
+         FullAdd,
+         PagerStatus,
 
-      Colours();
+         Error,
+         StatusLine
+      };
+
       static bool InitialiseColours();
    };
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -356,40 +356,40 @@ void Settings::SetColour(std::string property, std::string bg, std::string fg)
    int f = colourTable_[fg];
 
    if (property == "song") {
-      colours.Song = BACKGROUND(b) + f;
+      init_pair(colours.Song, f, b);
    }
    else if (property == "id") {
-      colours.SongId = BACKGROUND(b) + f;
+      init_pair(colours.SongId, f, b);
    }
    else if (property == "dir") {
-      colours.Directory = BACKGROUND(b) + f;
+      init_pair(colours.Directory, f, b);
    }
    else if (property == "current") {
-      colours.CurrentSong = BACKGROUND(b) + f;
+      init_pair(colours.CurrentSong, f, b);
    }
    else if (property == "match") {
-      colours.SongMatch = BACKGROUND(b) + f;
+      init_pair(colours.SongMatch, f, b);
    }
    else if (property == "partial") {
-      colours.PartialAdd = BACKGROUND(b) + f;
+      init_pair(colours.PartialAdd, f, b);
    }
    else if (property == "full") {
-      colours.FullAdd = BACKGROUND(b) + f;
+      init_pair(colours.FullAdd, f, b);
    }
    else if (property == "pager") {
-      colours.PagerStatus = BACKGROUND(b) + f;
+      init_pair(colours.PagerStatus, f, b);
    }
    else if (property == "error") {
-      colours.Error = BACKGROUND(b) + f;
+      init_pair(colours.Error, f, b);
    }
    else if (property == "status") {
-      colours.StatusLine = BACKGROUND(b) + f;
+      init_pair(colours.StatusLine, f, b);
    }
    else if (property == "tab") {
-      colours.TabWindow = BACKGROUND(b) + f;
+      init_pair(colours.TabWindow, f, b);
    }
    else if (property == "progress") {
-      colours.ProgressWindow = BACKGROUND(b) + f;
+      init_pair(colours.ProgressWindow, f, b);
    }
    else {
       ErrorString(ErrorNumber::UnknownOption, property);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -342,18 +342,34 @@ bool Settings::SkipConfigConnects() const
 
 void Settings::SetColour(std::string property, std::string bg, std::string fg)
 {
-   if (colourTable_.find(bg) == colourTable_.end() ||
-       colourTable_.find(fg) == colourTable_.end() ) {
-      ErrorString(ErrorNumber::UnknownOption, bg + " " + fg);
+   mutex_.lock();
+
+   Regex::RE const colours256Check("^(25[0-5]|2[0-4]\\d|1\\d{2}|[1-9]?\\d)$");
+   int f, b;
+
+   if(colourTable_.find(bg) != colourTable_.end()) {
+      b = colourTable_[bg];
+   }
+   else if(colours256Check.Matches(bg)) {
+      if(COLORS < 256) return;
+      b = stoi(bg);
+   }
+   else {
+      ErrorString(ErrorNumber::UnknownOption, bg);
       return;
    }
 
-   mutex_.lock();
-
-   if (fg == "default")
-      fg = "white";
-   int b = colourTable_[bg];
-   int f = colourTable_[fg];
+   if(colourTable_.find(fg) != colourTable_.end()) {
+      f = colourTable_[fg];
+   }
+   else if(colours256Check.Matches(fg)) {
+      if(COLORS < 256) return;
+      f = stoi(fg);
+   }
+   else {
+      ErrorString(ErrorNumber::UnknownOption, fg);
+      return;
+   }
 
    if (property == "song") {
       init_pair(colours.Song, f, b);


### PR DESCRIPTION
+ Updated the `:hi <prop> <bg> <fg>` command to accept numerical values
for foreground (`fg`) and background (`bg`) colors, ranging from 0 to 255. This allows users to utilize colors from the 256-color palette.

+ The command is ignored when numerical values for `fg` or `bg` are
used, if the terminal doesn't support 256 colors.

+ Maintains compatibility with the standard 16 terminal color strings
(e.g., black, red, blue, yellow, etc.).