### PR TITLE
Fix build with GCC 16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_PROG_CXX
 
 # Need to check this directory on bsd systems
 CPPFLAGS="$CPPFLAGS -I/usr/local/include -I/opt/local/include"
-CXXFLAGS="$CXXFLAGS -D__STRICT_ANSI__"
+CXXFLAGS="$CXXFLAGS -std=c++11"
 LDFLAGS="$LDFLAGS -L/opt/local/lib"
 
 AC_CHECK_HEADERS(sys/ioctl.h termios.h)


### PR DESCRIPTION
Otherwise `configure --disable-boost` fails on GCC 16.